### PR TITLE
fix: repoint dead preflight doc links (#1475)

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yml
@@ -23,7 +23,7 @@ body:
           required: true
         - label: I have searched the [issue tracker](https://github.com/ciderapp/Cider-2/issues) for a bug report that matches the one I want to file, without success.
           required: true
-        - label: I have confirmed that no [support FAQ](https://cider.sh/docs/client/faqs) resolves my issue.
+        - label: I have confirmed that no [support FAQ](https://github.com/ciderapp/Cider-2/tree/main?tab=readme-ov-file#faq) resolves my issue.
           required: true
         - label: I have checked that the correct behavior occurs on [Apple Music Web](https://music.apple.com) (if applicable).
           required: true

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -23,7 +23,7 @@ body:
           required: true
         - label: I have searched the [issue tracker](https://github.com/ciderapp/Cider-2/issues) for a bug report that matches the one I want to file, without success.
           required: true
-        - label: I have confirmed that no [support FAQ](https://cider.sh/docs/client/faqs) resolves my issue.
+        - label: I have confirmed that no [support FAQ](https://github.com/ciderapp/Cider-2/tree/main?tab=readme-ov-file#faq) resolves my issue.
           required: true
         - label: I have checked that the correct behavior occurs on [Apple Music Web](https://music.apple.com) (if applicable).
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,13 +2,13 @@ blank_issues_enabled: false
 
 contact_links:
   - name: Support Disclaimer
-    url: https://cider.sh/docs/client/disclaimer
+    url: https://cider.sh/legal/disclaimer
     about: Please read this before creating any issues.
   - name: Discord Support
     url: https://discord.com/invite/AppleMusic
     about: For quick support or if you have a feature you would like to request.
   - name: Cider Documentation
-    url: https://cider.sh/docs/client/faqs
+    url: https://github.com/ciderapp/Cider-2/tree/main?tab=readme-ov-file#faq
     about: In most cases, these troubleshooting tips can resolve basic issues. Try them out before opening an issue.
   - name: GitHub Issues
     url: https://github.com/ciderapp/Cider-2/issues


### PR DESCRIPTION
Fixes #1475.

The new-issue preflight checklist (and the blank-issue contact links) pointed at doc URLs that 404:

- `https://cider.sh/docs/client/faqs` (used in `1-bug.yml`, `bug.yml`, `config.yml`)
- `https://cider.sh/docs/client/disclaimer` (used in `config.yml`)

This repoints them to live pages:

- FAQ -> `https://github.com/ciderapp/Cider-2/tree/main?tab=readme-ov-file#faq` (the README FAQ section, which is also what the triage bot links to). If there is a canonical `docs.cider.sh` FAQ URL you would rather use, happy to swap it.
- Disclaimer -> `https://cider.sh/legal/disclaimer` (returns 200).

The Code of Conduct link (`https://cider.sh/legal/conduct`) still resolves, so it is left unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ciderapp/codesmith/Cider-2/pr/1540"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785206177&installation_id=125908741&pr_number=1540&repository=ciderapp%2FCider-2&return_to=https%3A%2F%2Fgithub.com%2Fciderapp%2FCider-2%2Fpull%2F1540&signature=c449bea396854d08c3b93c63e9fc8df752b4d17a5e2c024db95d1e1139acc631"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->